### PR TITLE
Reset the realm data and add additional users via env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ There are a number of tuxedo related properties that can be defined in order to 
 |TUX_EXPORT_N|Exported services - where N is a unique id to allow for multiple entries. This takes the form: `<unique name>=<local service name>\|<remote service name>\|<local ap name>\|<ejb>`. |TUX_EXPORT_0=ONLINE_SERVICES\|ONLINE_SERVICES\|CHIPS_EF_BATCH0_TUX\|tuxedo.services.OnlineServiceHome
 |TUX_IMPORT_N|Imported services - where N is a unique id to allow for multiple entries. This takes the form: `<unique name>=<local service name>\|<remote service name>\|<local ap name>\|<remote ap names>`.|TUX_IMPORT_0=CABS_Ord\|CABS_Ord\|CHIPS_EF_BATCH0_TUX\|CHIPS_TUX_FROM_CHIPS0,CHIPS_TUX_FROM_CHIPS1
 
-
+Optionally, the domain can be initialised with additional internal realm users specified by environment properties:
+|Property|Description  |Example
+|--|----|--
+|REALM_USER_N|Additional user to add to the realm.  This is mainly useful for adding users for the remote tuxedo domains, to allow for incoming calls.  This takes the form: `<unique name>=<username>\|<password>`.|REALM_USER_0=myusername\|mypassword
+    
 ## docker-compose
 docker-compose can be used to start all the required containers in one operation.
 

--- a/container-scripts/createUsers.sh
+++ b/container-scripts/createUsers.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# This script deletes any existing realm (ldap) data that may exist for the wladmin server
+# and then adds the required ldif entries into the DefaultAuthenticatorInit LDIF file for any users that 
+# are specified in environment variables.
+# The variable names are of the form REALM_USER_#, where # is a suffix to ensure each variable has a unique name.
+# The value of the variable is the username, then a pipe separator, then the password. E.g.:
+# REALM_USER_0=username|password
+
+
+DOMAIN_HOME="/apps/oracle/${DOMAIN_NAME}"
+LDIF_FILE=$DOMAIN_HOME/security/DefaultAuthenticatorInit.ldift
+
+echouser() {
+  echo "dn: uid=$1,ou=people,ou=@realm@,dc=@domain@"
+  echo "description: $1"
+  echo "objectclass: inetOrgPerson"
+  echo "objectclass: organizationalPerson"
+  echo "objectclass: person"
+  echo "objectclass: top"
+  echo "cn: $1"
+  echo "sn: $1"
+  echo "userpassword: $2"
+  echo "uid: $1"
+  echo "objectclass: wlsUser"
+  echo 
+}
+
+# Remove any existing realm data so that it is reloaded from the LDIF files
+rm -rf ${DOMAIN_HOME}/servers/wladmin/data/ldap
+
+# Loop through all REALM_USER env vars and add the user to the DefaultAuthenticatorInit LDIF file
+REALM_USERS=$(env | sort | grep "^REALM_USER_")
+for REALM_USER in ${REALM_USERS};
+do
+  while IFS='|' read -r REALM_USER_NAME REALM_USER_PASSWORD;
+  do
+    echouser ${REALM_USER_NAME} ${REALM_USER_PASSWORD} >> ${LDIF_FILE}
+  done < <(echo ${REALM_USER##*=})
+done

--- a/container-scripts/createUsers.sh
+++ b/container-scripts/createUsers.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# This script deletes any existing realm (ldap) data that may exist for the wladmin server
-# and then adds the required ldif entries into the DefaultAuthenticatorInit LDIF file for any users that 
-# are specified in environment variables.
+# This script deletes any existing realm (LDAP) data that may exist for the wladmin server
+# and then adds the required entries into the DefaultAuthenticatorInit LDIF file for any users that 
+# are specified in environment variables. LDIF=LDAP Data Interchange Format - see https://datatracker.ietf.org/doc/html/rfc2849.
 # The variable names are of the form REALM_USER_#, where # is a suffix to ensure each variable has a unique name.
 # The value of the variable is the username, then a pipe separator, then the password. E.g.:
 # REALM_USER_0=username|password

--- a/container-scripts/startAdmin.sh
+++ b/container-scripts/startAdmin.sh
@@ -19,6 +19,9 @@ mkdir -p ${DOMAIN_HOME}/servers/${ADMIN_NAME}/security
 echo "username=weblogic" > ${DOMAIN_HOME}/servers/${ADMIN_NAME}/security/boot.properties
 echo "password=${ADMIN_PASSWORD}" >> ${DOMAIN_HOME}/servers/${ADMIN_NAME}/security/boot.properties
 
+# Delete any existing realm data and add any users defined in env vars
+${ORACLE_HOME}/container-scripts/createUsers.sh
+
 # Generate and set the tuxedo configuration from the environment
 cd ${DOMAIN_HOME}/config
 ${ORACLE_HOME}/container-scripts/generateTuxedoConfigFromEnv.sh > tuxedo-config.xml


### PR DESCRIPTION
Allow additional users to be provided by environment variables, e.g.:
REALM_USER_0=username|password
REALM_USER_2=anotherusername|anotherpassword

This allows the remote tuxedo domains to have corresponding users automatically set up in the WebLogic realm when the wladmin container is started.

Resolves: https://companieshouse.atlassian.net/browse/CM-913