### PR TITLE
Reference ch-weblogic version 1.5.1 to bring in new WL patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:1.5.0
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:1.5.1
 
 # IMPORTANT - the default admin password should be supplied as a build arg
 # e.g. --build-arg ADMIN_PASSWORD=notsecure123.  This password will be visible in the image


### PR DESCRIPTION
Update the version of ch-weblogic base image to pull in new WebLogic patches.

Resolves: https://companieshouse.atlassian.net/browse/CM-1157