### PR TITLE
Enable graceful shutdown timeout and ignore web sessions

### DIFF
--- a/config/config.xml
+++ b/config/config.xml
@@ -97,6 +97,8 @@
       <cluster>wlcluster</cluster>
     </jta-migratable-target>
     <weblogic-plugin-enabled>true</weblogic-plugin-enabled>
+    <graceful-shutdown-timeout>30</graceful-shutdown-timeout>
+    <ignore-sessions-during-shutdown>true</ignore-sessions-during-shutdown>
   </server>
   <cluster>
     <name>wlcluster</name>


### PR DESCRIPTION
This makes a clean/graceful shutdown of the tuxedo proxies easier, by ignoring web sessions.  Without this, we have to do a forced shutdown or wait until sessions expire.