### PR TITLE
Reference version 1.5.4 of ch-weblogic to bring weblogic patch changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:1.5.1
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:1.5.4
 
 # IMPORTANT - the default admin password should be supplied as a build arg
 # e.g. --build-arg ADMIN_PASSWORD=notsecure123.  This password will be visible in the image


### PR DESCRIPTION
Refer 1.5.4 image version to apply latest patches to WebLogic .

Resolves:
https://companieshouse.atlassian.net/browse/SUP-1136