### PR TITLE
Add default admin console provider

### DIFF
--- a/container-scripts/startAdmin.sh
+++ b/container-scripts/startAdmin.sh
@@ -39,4 +39,10 @@ ${ORACLE_HOME}/oracle_common/common/bin/wlst.sh -skipWLSModuleScanning ${ORACLE_
 # Prevent Derby from being started
 export DERBY_FLAG=false
 
+# Generate a user-projects.json file from a template to create a default provider in the admin console
+CONSOLE_PERSISTENCE_DIR=${DOMAIN_HOME}/remote-console-persistence/weblogic
+mkdir -p ${CONSOLE_PERSISTENCE_DIR}
+envsubst < ${ORACLE_HOME}/container-scripts/user-projects.json.template > ${CONSOLE_PERSISTENCE_DIR}/user-projects.json
+chmod 400 ${CONSOLE_PERSISTENCE_DIR}/user-projects.json
+
 ${DOMAIN_HOME}/bin/startWebLogic.sh $*

--- a/container-scripts/user-projects.json.template
+++ b/container-scripts/user-projects.json.template
@@ -1,0 +1,14 @@
+{
+  "name" : "Hosted WebLogic Remote Console",
+  "label" : "Hosted WebLogic Remote Console",
+  "dataProviders" : [ {
+    "name" : "${APP_INSTANCE_NAME}",
+    "type" : "adminserver",
+    "url" : "http://wladmin:7001",
+    "username" : "${WEBLOGIC_ADMIN_USERNAME}",
+    "settings" : {
+      "proxyOverride" : ""
+    }
+  } ],
+  "current" : true
+}


### PR DESCRIPTION
Add a default provider configuration, so that it doesn't have to be created manually when logging into the Weblogic admin console

Resolves:
https://companieshouse.atlassian.net/browse/CHP-999