### PR TITLE
Reference ch-weblogic 2.0.4 to pull in Jan 2026 security fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:2.0.3 AS builder
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:2.0.4 AS builder
 
 # IMPORTANT - the default admin password should be supplied as a build arg
 # e.g. --build-arg ADMIN_PASSWORD=notsecure123.  This password MUST later be reset
@@ -37,7 +37,7 @@ RUN cd ${DOMAIN_NAME}/chipsconfig && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/weblogic-tux-hostname-patch/1.0.0/weblogic-tux-hostname-patch-1.0.0.jar -o weblogic-tux-hostname-patch-1.0.0.jar && \
     curl -L -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_PASSWORD}" ${ARTIFACTORY_BASE_URL}/uk/gov/companieshouse/weblogic-tux-hostname-patch/2.0.0/weblogic-tux-hostname-patch-2.0.0.jar -o weblogic-tux-hostname-patch-2.0.0.jar
 
-FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:2.0.3
+FROM 300288021642.dkr.ecr.eu-west-2.amazonaws.com/ch-weblogic:2.0.4
 
 ENV DOMAIN_NAME=chipsdomain
 ENV DOMAIN_HOME=${ORACLE_HOME}/${DOMAIN_NAME} \

--- a/container-scripts/await-admin-server-startup.py
+++ b/container-scripts/await-admin-server-startup.py
@@ -20,7 +20,7 @@ def checkConnection(adminUsername, adminPassword, adminServerT3):
 adminServerT3 = 't3://wladmin:7001'
 adminUsername = 'weblogic'
 adminPassword = os.environ.get("ADMIN_PASSWORD")
-timeout = 120
+timeout = os.environ.get("WLADMIN_AWAIT_TIMEOUT", 180)
 
 
 #Check if the server can be connected to


### PR DESCRIPTION
Use new ch-weblogic base image to pull in the Jan 2026 Oracle patches and JDK 21.0.10

Also adds a parameter to allow adjustment of the admin server startup timeout, to match the functionality and default value already available in chips-domain.

Partially resolves:
https://companieshouse.atlassian.net/browse/CHP-1000